### PR TITLE
Refactor powershell sample

### DIFF
--- a/policies/ucs_domain_policies/flow_control_policy/powershell/flow_control_policy.ps1
+++ b/policies/ucs_domain_policies/flow_control_policy/powershell/flow_control_policy.ps1
@@ -8,9 +8,9 @@ $config = @{
 # set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default
 
 #Create fabric control policy
 $result = New-IntersightFabricFlowControlPolicy -Name "fabric_flow" -ReceiveDirection Enabled -SendDirection Enabled `
-         -PriorityFlowControlMode Off -Organization $orgRef -Description "fabric flow control"
+         -PriorityFlowControlMode Off -Organization $org -Description "fabric flow control"

--- a/policies/ucs_domain_policies/link_aggregation_policy/powershell/link_aggregation_policy.ps1
+++ b/policies/ucs_domain_policies/link_aggregation_policy/powershell/link_aggregation_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default
 
 $result = New-IntersightFabricLinkAggregationPolicy -Name "LinkAgrregate" -Description "Link Aggregation policy" `
-          -LacpRate Fast -SuspendIndividual $true -Organization $orgRef
+          -LacpRate Fast -SuspendIndividual $true -Organization $org

--- a/policies/ucs_domain_policies/link_control_policy/powershell/link_control_policy.ps1
+++ b/policies/ucs_domain_policies/link_control_policy/powershell/link_control_policy.ps1
@@ -8,11 +8,11 @@ $config = @{
 # set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # Initialize the fabric udld setting
 $fabricUdldSetting = Initialize-IntersightFabricUdldSettings -AdminState Enabled -Mode Normal
 
 $result = New-IntersightFabricLinkControlPolicy -Name "fabric_link_policy" -Description "fabric link control" `
-          -UdldSettings $fabricUdldSetting -Organization $orgRef
+          -UdldSettings $fabricUdldSetting -Organization $org

--- a/policies/ucs_domain_policies/multicast_policy/powershell/multicast_policy.ps1
+++ b/policies/ucs_domain_policies/multicast_policy/powershell/multicast_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $result = New-IntersightFabricMulticastPolicy -Name "fabricMultiCastPolicy" -QuerierState Enabled `
-          -SnoopingState Enabled -QuerierIpAddress "11.11.11.11" -Organization $orgRef
+          -SnoopingState Enabled -QuerierIpAddress "11.11.11.11" -Organization $org

--- a/policies/ucs_domain_policies/network_connectivity_policy/powershell/network_connectivity_policy.ps1
+++ b/policies/ucs_domain_policies/network_connectivity_policy/powershell/network_connectivity_policy.ps1
@@ -8,10 +8,10 @@ $config = @{
 # set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $result = New-IntersightNetworkconfigPolicy -Name "netwrokConfigPolicy" -Description "test network config policy" `
           -EnableDynamicDns $true -DynamicDnsDomain "xyz.com" -EnableIpv6 $false `
           -AlternateIpv4dnsServer "22.22.22.22" -PreferredIpv4dnsServer "171.70.98.1" `
-          -Organization $orgRef 
+          -Organization $org 

--- a/policies/ucs_domain_policies/network_control_policy/powershell/network_control_policy.ps1
+++ b/policies/ucs_domain_policies/network_control_policy/powershell/network_control_policy.ps1
@@ -8,19 +8,19 @@ $config = @{
 # set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # initialize vlan settings
 $vlanSetting = Initialize-IntersightVnicVlanSettings -AllowedVlans "11-19" -DefaultVlan 11 -Mode ACCESS
 
 # create ethNetwork policy and get ref of it
-$networkRef = New-IntersightvnicEthNetworkPolicy -name "vnic_eth_network_policy_1" -TargetPlatform FIAttached `
-              -VlanSettings $vlanSetting -Organization $orgRef | Get-IntersightMoMoRef
+$network = New-IntersightvnicEthNetworkPolicy -name "vnic_eth_network_policy_1" -TargetPlatform FIAttached `
+              -VlanSettings $vlanSetting -Organization $org 
 
 $lldpSetting = Initialize-IntersightFabricLldpSettings -ReceiveEnabled $true -TransmitEnabled $true
 
 $result = New-IntersightFabricEthNetworkControlPolicy -Name "networkControlPolicy" -CdpEnabled $true `
           -UplinkFailAction Warning -MacRegistrationMode NativeVlanOnly -ForgeMac Allow `
-          -LldpSettings $lldpSetting -NetworkPolicy $networkRef -Organization $orgRef
+          -LldpSettings $lldpSetting -NetworkPolicy $network -Organization $org
         

--- a/policies/ucs_domain_policies/network_group_policy/powershell/network_group_policy.ps1
+++ b/policies/ucs_domain_policies/network_group_policy/powershell/network_group_policy.ps1
@@ -8,10 +8,10 @@ $config = @{
 # set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # initialize vlan settings
 $valnSetting = Initialize-IntersightFabricVlanSettings -AllowedVlans 14 -NativeVlan 14
 
-$result = New-IntersightFabricEthNetworkGroupPolicy -Name "fabricEthNetorkGroupPolicy" -VlanSettings $valnSetting -Organization $orgRef
+$result = New-IntersightFabricEthNetworkGroupPolicy -Name "fabricEthNetorkGroupPolicy" -VlanSettings $valnSetting -Organization $org

--- a/policies/ucs_domain_policies/ntp_policy/powershell/ntp_policy.ps1
+++ b/policies/ucs_domain_policies/ntp_policy/powershell/ntp_policy.ps1
@@ -8,7 +8,7 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# Get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
-$result = New-IntersightNtpPolicy -Name "ntp_policy_1" -Enabled $true -NtpServers @("44.44.44.44") -Organization $orgRef
+$result = New-IntersightNtpPolicy -Name "ntp_policy_1" -Enabled $true -NtpServers @("44.44.44.44") -Organization $org

--- a/policies/ucs_domain_policies/port_policy/powershell/port_policy.ps1
+++ b/policies/ucs_domain_policies/port_policy/powershell/port_policy.ps1
@@ -8,7 +8,7 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
-$result = New-IntersightFabricPortPolicy -Name "port_policy_1" -DeviceModel UCSFI64108 -Organization $orgRef
+$result = New-IntersightFabricPortPolicy -Name "port_policy_1" -DeviceModel UCSFI64108 -Organization $org

--- a/policies/ucs_domain_policies/snmp_policy/powershell/snmp_policy.ps1
+++ b/policies/ucs_domain_policies/snmp_policy/powershell/snmp_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $snmpTrap = Initialize-IntersightSnmpTrap -Community "trapCommString" -Destination "11.11.11.11" -Enabled $true `
             -Port 162 -Type Trap -Version V2
@@ -18,5 +18,5 @@ $snmpUser = Initialize-IntersightSnmpUser -AuthType MD5 -Name user1 -PrivacyPass
            -PrivacyType AES -SecurityLevel AuthPriv
 
 $result = New-IntersightSnmpPolicy -Name "snmp_policy" -AccessCommunityString accCommString -CommunityAccess Disabled `
-         -Enabled $true -EngineId "EngineID" -SnmpPort 161 -Organization $orgRef `
+         -Enabled $true -EngineId "EngineID" -SnmpPort 161 -Organization $org `
          -SnmpTraps @($snmpTrap) -SnmpUsers @($snmpUser)

--- a/policies/ucs_domain_policies/switch_control_policy/powershell/switch_control_policy.ps1
+++ b/policies/ucs_domain_policies/switch_control_policy/powershell/switch_control_policy.ps1
@@ -8,12 +8,12 @@ $config = @{
     # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $macAge = Initialize-IntersightFabricMacAgingSettings -MacAgingOption Default -MacAgingTime 14500
 
 $udldSetting = Initialize-IntersightFabricUdldGlobalSettings -MessageInterval 12 -RecoveryAction None
 
 $result = New-IntersightFabricSwitchControlPolicy -Name "switch_control_policy_1" -EthernetSwitchingMode Switch -FcSwitchingMode Switch `
-        -MacAgingSettings $macAge -UdldSettings $udldSetting -Organization $orgRef
+        -MacAgingSettings $macAge -UdldSettings $udldSetting -Organization $org

--- a/policies/ucs_domain_policies/syslog_policy/powershell/syslog_policy.ps1
+++ b/policies/ucs_domain_policies/syslog_policy/powershell/syslog_policy.ps1
@@ -8,12 +8,12 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $localClient = Initialize-IntersightSyslogLocalClientBase -MinSeverity Warning -ClassId SyslogLocalFileLoggingClient -ObjectType SyslogLocalFileLoggingClient
 
 $remoteClient = Initialize-IntersightSyslogRemoteClientBase -Enabled $true -Hostname "11.11.11.11" -MinSeverity Warning `
                 -Port 514 -Protocol Udp -ClassId SyslogRemoteLoggingClient -ObjectType SyslogRemoteLoggingClient
 
-$result = New-IntersightSyslogPolicy -Name "sys_log_policy1" -LocalClients @($localClient) -RemoteClients @($remoteClient) -Organization $orgRef
+$result = New-IntersightSyslogPolicy -Name "sys_log_policy1" -LocalClients @($localClient) -RemoteClients @($remoteClient) -Organization $org

--- a/policies/ucs_domain_policies/system_qos_policy/powershell/system_qos_policy.ps1
+++ b/policies/ucs_domain_policies/system_qos_policy/powershell/system_qos_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $qosSilver = Initialize-IntersightFabricQosClass -AdminState Enabled -BandwidthPercent 15 -Name Silver -PacketDrop $true -Weight 7 -Mtu 1500 -Cos 1
 
@@ -19,4 +19,4 @@ $qoSGold = Initialize-IntersightFabricQosClass -Name Gold -Weight 9 -BandwidthPe
 
 $qosPlatinum = Initialize-IntersightFabricQosClass -Name Platinum -AdminState Enabled -BandwidthPercent 22 -Cos 5 -Mtu 1500 -Weight 10 -PacketDrop $true
 
-$qosPolicy = New-IntersightFabricSystemQosPolicy -Name "qos_policy_1" -Classes @($qosPlatinum,$qoSGold,$qosSilver,$qosBronze) -Organization $orgRef
+$qosPolicy = New-IntersightFabricSystemQosPolicy -Name "qos_policy_1" -Classes @($qosPlatinum,$qoSGold,$qosSilver,$qosBronze) -Organization $org

--- a/policies/ucs_domain_policies/vlan_configuration_policy/powershell/vlan_configuration_policy.ps1
+++ b/policies/ucs_domain_policies/vlan_configuration_policy/powershell/vlan_configuration_policy.ps1
@@ -8,19 +8,13 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default
 
 $multiCastPolicy = New-IntersightFabricMulticastPolicy -Name "fabricMultiCastPolicy" -QuerierState Enabled `
-                 -SnoopingState Enabled -QuerierIpAddress "11.11.11.11" -Organization $orgRef
+                 -SnoopingState Enabled -QuerierIpAddress "11.11.11.11" -Organization $org
 
-$multiCastRef = $multiCastPolicy | Get-IntersightMoMoRef
+$EthNetwrkPolicy = New-IntersightFabricEthNetworkPolicy -Name "netwrkPolicy" -Organization $org -Description "native network policy"
 
-$EthNetwrkPolicy = New-IntersightFabricEthNetworkPolicy -Name "netwrkPolicy" -Organization $orgRef -Description "native network policy"
-
-$ethNetworkPolicyRef = $EthNetwrkPolicy | Get-IntersightMoMoRef
-
-$result = New-IntersightFabricVlan -Name "valn_23" -AutoAllowOnUplinks $false -EthNetworkPolicy $ethNetworkPolicyRef `
-          -MulticastPolicy $multiCastRef -IsNative $false -VlanId 23
-
-
+$result = New-IntersightFabricVlan -Name "valn_23" -AutoAllowOnUplinks $false -EthNetworkPolicy $EthNetwrkPolicy `
+          -MulticastPolicy $multiCastPolicy -IsNative $false -VlanId 23

--- a/policies/ucs_domain_policies/vsan_configuration_policy/powershell/vsan_configuration_policy.ps1
+++ b/policies/ucs_domain_policies/vsan_configuration_policy/powershell/vsan_configuration_policy.ps1
@@ -8,13 +8,11 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default
 
 # create a new network policy or get the existing one using Get-IntersightFabricFcNetworkPolicy
-$fcNetworkPolicy = New-IntersightFabricFcNetworkPolicy -Name "fc_network_policy_1" -EnableTrunking $false -Organization $orgRef
+$fcNetworkPolicy = New-IntersightFabricFcNetworkPolicy -Name "fc_network_policy_1" -EnableTrunking $false -Organization $org
 
-$fcNetworkPolicyRef = $fcNetworkPolicy | Get-IntersightMoMoRef
-
-$vsanPolicy = New-IntersightFabricVsan -Name "vsan_110" -DefaultZoning Disabled -VsanScope Uplink -FcoeVlan 1120 -VsanId 110 -FcNetworkPolicy $fcNetworkPolicyRef
+$vsanPolicy = New-IntersightFabricVsan -Name "vsan_110" -DefaultZoning Disabled -VsanScope Uplink -FcoeVlan 1120 -VsanId 110 -FcNetworkPolicy $fcNetworkPolicy
 

--- a/policies/ucs_server_policies/compute/bios_policy/powershell/bios_policy.ps1
+++ b/policies/ucs_server_policies/compute/bios_policy/powershell/bios_policy.ps1
@@ -11,9 +11,6 @@ Set-IntersightConfiguration @config
 # get the existing default org. One can create new Organization using New-IntersightOrganizationOrganization cmdlets.
 $org = Get-IntersightOrganizationOrganization -Name default 
 
-# get oragnizationRef
-$orgRef = $org | Get-IntersightMoMoRef
-
 # create a bios policy
 $result = New-IntersightBiosPolicy -Name "bios_policy_1" -IntelHyperThreadingTech Enabled -IntelTurboBoostTech Enabled `
-         -EnhancedIntelSpeedStepTech Enabled -HardwarePrefetch Enabled -EnergyEfficientTurbo Disabled  -Organization $orgRef
+         -EnhancedIntelSpeedStepTech Enabled -HardwarePrefetch Enabled -EnergyEfficientTurbo Disabled  -Organization $org

--- a/policies/ucs_server_policies/compute/boot_order_policy/powershell/boot_order_policy.ps1
+++ b/policies/ucs_server_policies/compute/boot_order_policy/powershell/boot_order_policy.ps1
@@ -11,9 +11,6 @@ Set-IntersightConfiguration @config
 # get the existing default org. One can create new Organization using New-IntersightOrganizationOrganization cmdlets.
 $org = Get-IntersightOrganizationOrganization -Name default 
 
-# get the organizationRef
-$orgRef = $org | Get-IntersightMoMoRef
-
 # initialize vmedia boot device
 $vmediaBoot = Initialize-IntersightBootVirtualMedia -Enabled $true -Subtype CimcMappedHdd -Name "vMedia" -ClassId BootVirtualMedia -ObjectType BootVirtualMedia
 
@@ -33,4 +30,4 @@ $sanBoot = Initialize-IntersightBootSan -ClassId BootSan -ObjectType BootSan -En
            -Name "secondary" -Wwpn "50:06:01:62:3E:E0:58:36" -Bootloader $bootLoader
 
 # create a boot precision policy with above created boot devices
-$BootPrecisionPolicy = New-IntersightBootPrecisionPolicy -Name "BootPrecision_1" -BootDevices @($vmediaBoot, $usbBoot, $uefiBoot, $pxeBoot,$sanBoot) -Organization $orgRef 
+$BootPrecisionPolicy = New-IntersightBootPrecisionPolicy -Name "BootPrecision_1" -BootDevices @($vmediaBoot, $usbBoot, $uefiBoot, $pxeBoot,$sanBoot) -Organization $org 

--- a/policies/ucs_server_policies/compute/power_policy/powershell/power_policy.ps1
+++ b/policies/ucs_server_policies/compute/power_policy/powershell/power_policy.ps1
@@ -11,10 +11,7 @@ Set-IntersightConfiguration @config
 # get the existing default org. One can create new Organization using New-IntersightOrganizationOrganization cmdlets.
 $org = Get-IntersightOrganizationOrganization -Name default 
 
-# get the organizationRef
-$orgRef = $org | Get-IntersightMoMoRef
-
 # create a power policy
 $result = New-IntersightPowerPolicy -Name "power_policy_1" -DynamicRebalancing Disabled -ExtendedPowerCapacity Enabled `
           -PowerPriority Low -PowerProfiling Enabled -PowerRestoreState AlwaysOff -PowerSaveMode Enabled `
-          -RedundancyMode Grid -Organization $orgRef
+          -RedundancyMode Grid -Organization $org

--- a/policies/ucs_server_policies/compute/virtual_media_policy/powershell/virtual_media_policy.ps1
+++ b/policies/ucs_server_policies/compute/virtual_media_policy/powershell/virtual_media_policy.ps1
@@ -11,11 +11,8 @@ Set-IntersightConfiguration @config
 # get the existing default org. One can create new Organization using New-IntersightOrganizationOrganization cmdlets.
 $org = Get-IntersightOrganizationOrganization -Name default 
 
-# get the organizationRef 
-$orgRef = $org | Get-IntersightMoMoRef
-
 # initialize vmedia mapping 
 $vmediaMapping = Initialize-IntersightVmediaMapping -AuthenticationProtocol None -DeviceType Cdd -FileLocation "nfs://10.193.167.6/exports/vms/ucs-c240m5-huu-3.1.3h.iso"`
                 -HostName "12.11.11.13" -MountProtocol Nfs  -VolumeName v0
 # create a new vmedia policy by passing the above created vmedia mapping
-$result = New-IntersightVmediaPolicy -Name "vmedia_policy_1" -Enabled $true -Encryption $true -Mappings @($vmediaMapping) -LowPowerUsb $true -Organization $orgRef
+$result = New-IntersightVmediaPolicy -Name "vmedia_policy_1" -Enabled $true -Encryption $true -Mappings @($vmediaMapping) -LowPowerUsb $true -Organization $org

--- a/policies/ucs_server_policies/management/imc_access_policy/powershell/imc_access_policy.ps1
+++ b/policies/ucs_server_policies/management/imc_access_policy/powershell/imc_access_policy.ps1
@@ -11,25 +11,20 @@ Set-IntersightConfiguration @config
 # get the existing default org. One can create new Organization using New-IntersightOrganizationOrganization cmdlets.
 $org = Get-IntersightOrganizationOrganization -Name default 
 
-# get organizationRef
-$orgRef = $org | Get-IntersightMoMoRef
-
 $addressType = Initialize-IntersightAccessAddressType -EnableIpV4 $true -EnableIpV6 $false
 
 $configurationType = Initialize-IntersightAccessConfigurationType -ConfigureInband $true -ConfigureOutOfBand $false
 
 # get the existing Ipv4_pool if already created 
-# $ipPoolRef = Get-IntersightIppoolPool -Name "Ipv4_pool" | Get-IntersightMoMoRef
+# $ipPool = Get-IntersightIppoolPool -Name "Ipv4_pool" 
 
 # create New IP pool using New-IntersightIppoolPool
 $ipv4Block = Initialize-IntersightIppoolIpV4Block -From "10.128.130.100" -Size 10
 
 $ipv4Config = Initialize-IntersightIppoolIpV4Config -Gateway "10.128.130.254" -Netmask "255.255.255.0"
 
-$ipv4Pool = New-IntersightIppoolPool -Name "ipv4_ippool_1" -AssignmentOrder Default -IpV4Blocks $ipv4Block -IpV4Config $ipv4Config -Organization $orgRef
-
-$ipPoolRef = $ipv4Pool | Get-IntersightMoMoRef
+$ipv4Pool = New-IntersightIppoolPool -Name "ipv4_ippool_1" -AssignmentOrder Default -IpV4Blocks $ipv4Block -IpV4Config $ipv4Config -Organization $org
 
 # create a access policy
 $result = New-IntersightAccessPolicy -Name "access_policy_1" -AddressType $addressType -ConfigurationType $configurationType `
-          -InbandIpPool $ipPoolRef -Organization $orgRef -InbandVlan 144
+          -InbandIpPool $ipv4Pool -Organization $org -InbandVlan 144

--- a/policies/ucs_server_policies/management/local_user_policy/powershell/local_user_policy.ps1
+++ b/policies/ucs_server_policies/management/local_user_policy/powershell/local_user_policy.ps1
@@ -12,24 +12,18 @@ Set-IntersightConfiguration @config
 # get the existing default org. One can create new Organization using New-IntersightOrganizationOrganization cmdlets.
 $org = Get-IntersightOrganizationOrganization -Name default 
 
-# get organizationRef
-$orgRef = $org | Get-IntersightMoMoRef
-
 # create a user name guest.
-$user = New-IntersightIamEndPointUser -Name guest -Organization $orgRef
-$userRef = $user | Get-IntersightMoMoRef
+$user = New-IntersightIamEndPointUser -Name guest -Organization $org
 
 # initialize password properties to create policy and assign  the policy to User Policy
 $passwordProperty = Initialize-IntersightIamEndPointPasswordProperties -PasswordHistory 5 -EnforceStrongPassword $true -ForceSendPassword $true `
                     -GracePeriod 2 -NotificationPeriod 1
 # create a user policy
-$userPolicy = New-IntersightIamEndPointUserPolicy -Name "user_policy_1" -PasswordProperties $passwordProperty -Organization $orgRef 
-
-$userPolicyRef = $userPolicy| Get-IntersightMoMoRef
+$userPolicy = New-IntersightIamEndPointUserPolicy -Name "user_policy_1" -PasswordProperties $passwordProperty -Organization $org 
 
 # get admin role ref which will be assigned to above created user
-$adminRoleRef = Get-IntersightIamEndPointRole -Name "admin" | Get-IntersightMoMoRef
+$adminRole = Get-IntersightIamEndPointRole -Name "admin" 
 
-# create endpoint userRole and get the MoRef of it
-$endPointUserRoleRef = New-IntersightIamEndPointUserRole -Enabled $true -EndPointRole $adminRoleRef -Password "admin@1234" `
-                       -EndPointUser $userRef  -EndPointUserPolicy $userPolicyRef | Get-IntersightMoMoRef
+# create endpoint userRole
+$endPointUserRole = New-IntersightIamEndPointUserRole -Enabled $true -EndPointRole $adminRole -Password "admin@1234" `
+                       -EndPointUser $user  -EndPointUserPolicy $userPolicy 

--- a/policies/ucs_server_policies/management/serial_over_lan_policy/powershell/serial_over_lan_policy.ps1
+++ b/policies/ucs_server_policies/management/serial_over_lan_policy/powershell/serial_over_lan_policy.ps1
@@ -10,8 +10,7 @@ Set-IntersightConfiguration @config
 
 # get the existing default org. One can create new Organization using New-IntersightOrganizationOrganization cmdlets.
 $org = Get-IntersightOrganizationOrganization -Name default 
-$orgRef = $org | Get-IntersightMoMoRef
 
 # create a SOL policy.
 $solPolicy = New-IntersightSolPolicy -Name "sample_sol_policy" -BaudRate NUMBER_19200 -ComPort Com0 -Enabled $true `
-            -SshPort 2120 -Organization $orgRef
+            -SshPort 2120 -Organization $org

--- a/policies/ucs_server_policies/management/snmp_policy/powershell/snmp_policy.ps1
+++ b/policies/ucs_server_policies/management/snmp_policy/powershell/snmp_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # initialize SNMP trap
 $snmpTrap = Initialize-IntersightSnmpTrap -Community "trapCommString" -Destination "11.11.11.11" -Enabled $true `
@@ -21,5 +21,5 @@ $snmpUser = Initialize-IntersightSnmpUser -AuthType MD5 -Name user1 -PrivacyPass
 
 # create a SNMP policy
 $result = New-IntersightSnmpPolicy -Name "snmp_policy_1" -AccessCommunityString accCommString -CommunityAccess Disabled `
-         -Enabled $true -EngineId "EngineID" -SnmpPort 161 -SysContact "xyz@test.com" -SysLocation "NYK" -Organization $orgRef `
+         -Enabled $true -EngineId "EngineID" -SnmpPort 161 -SysContact "xyz@test.com" -SysLocation "NYK" -Organization $org `
          -SnmpTraps @($snmpTrap) -SnmpUsers @($snmpUser)

--- a/policies/ucs_server_policies/management/syslog_policy/powershell/syslog_policy.ps1
+++ b/policies/ucs_server_policies/management/syslog_policy/powershell/syslog_policy.ps1
@@ -8,12 +8,12 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $localClient = Initialize-IntersightSyslogLocalClientBase -MinSeverity Warning -ClassId SyslogLocalFileLoggingClient -ObjectType SyslogLocalFileLoggingClient
 
 $remoteClient = Initialize-IntersightSyslogRemoteClientBase -Enabled $true -Hostname "11.11.11.11" -MinSeverity Warning `
                 -Port 514 -Protocol Udp -ClassId SyslogRemoteLoggingClient -ObjectType SyslogRemoteLoggingClient
 
-$result = New-IntersightSyslogPolicy -Name "sys_log_policy1" -LocalClients @($localClient) -RemoteClients @($remoteClient) -Organization $orgRef
+$result = New-IntersightSyslogPolicy -Name "sys_log_policy1" -LocalClients @($localClient) -RemoteClients @($remoteClient) -Organization $org

--- a/policies/ucs_server_policies/management/virtual_kvm_policy/powershell/virtual_kvm_policy.ps1
+++ b/policies/ucs_server_policies/management/virtual_kvm_policy/powershell/virtual_kvm_policy.ps1
@@ -8,10 +8,10 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$newOrg = Get-IntersightOrganizationOrganization -Name default
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default
 
 # create a kvm policy
 $kvmPolicy = New-IntersightKvmPolicy -Name "kvm_policy_1" -Description "Kvm policy for sample" `
                                     -EnableVideoEncryption $true -EnableLocalServerVideo $true `
-                                    -Enabled $true -MaximumSessions 2 -Organization $newOrg
+                                    -Enabled $true -MaximumSessions 2 -Organization $org

--- a/policies/ucs_server_policies/misc/ldap_policy/powershell/ldap_policy.ps1
+++ b/policies/ucs_server_policies/misc/ldap_policy/powershell/ldap_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 #initialize ldap base properties
 $baseProperty = Initialize-IntersightIamLdapBaseProperties -Attribute "CiscoAvPair" -BaseDn "DC=new,DC=com" -BindMethod Anonymous `
@@ -21,13 +21,11 @@ $dnsParameter = Initialize-IntersightIamLdapDnsParameters -Source Extracted
 
 # create a ldap policy
 $ldapPolicy = New-IntersightIamLdapPolicy -Name "ldap_policy_1" -BaseProperties $baseProperty -DnsParameters $dnsParameter `
-          -Enabled $true -Organization $orgRef
-
-$ldapPolicyRef = $ldapPolicy | Get-IntersightMoMoRef
+          -Enabled $true -Organization $org
 
 # add provider to ldap policy
-$ldapProviderRef = New-IntersightIamLdapProvider -Port 389 -Server "ldap.xyz.com" -LdapPolicy $ldapPolicyRef  | Get-IntersightMoMoRef
+$ldapProvider = New-IntersightIamLdapProvider -Port 389 -Server "ldap.xyz.com" -LdapPolicy $ldapPolicy  
 
 # add policy to ldap group
-$endPointRoleRef = Get-IntersightIamEndPointRole -Name admin | Get-IntersightMoMoRef
-$ldapGroup = New-IntersightIamLdapGroup -Domain "xyz.com" -Name "ldap_group" -LdapPolicy $ldapPolicy -EndPointRole $endPointRoleRef
+$endPointRole = Get-IntersightIamEndPointRole -Name admin 
+$ldapGroup = New-IntersightIamLdapGroup -Domain "xyz.com" -Name "ldap_group" -LdapPolicy $ldapPolicy -EndPointRole $endPointRole

--- a/policies/ucs_server_policies/misc/ntp_policy/powershell/ntp_policy.ps1
+++ b/policies/ucs_server_policies/misc/ntp_policy/powershell/ntp_policy.ps1
@@ -9,8 +9,8 @@ $config = @{
 Set-IntersightConfiguration @config
 
 #Get torganization ref if it is exist, or create a new organization using New-IntersightOrganizationOrganization
-$newOrgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $ntpPolicy = New-IntersightNtpPolicy -Name "PSNtp" -Description "ntp policy for PSOrg" `
                                      -NtpServers @("22.22.22.22","77.77.77.77") `
-                                     -Enabled $true -Timezone IndianMauritius -Organization $newOrgRef
+                                     -Enabled $true -Timezone IndianMauritius -Organization $org

--- a/policies/ucs_server_policies/misc/smtp_policy/powershell/smtp_policy.ps1
+++ b/policies/ucs_server_policies/misc/smtp_policy/powershell/smtp_policy.ps1
@@ -8,9 +8,9 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # create a smtp policy
 $smtpPolicy = New-IntersightSmtpPolicy -Name "smtp_policy_1" -MinSeverity Critical -Enabled $true -SmtpPort 25 `
-             -SmtpServer "22.22.22.22" -SmtpRecipients @("xyz@test.com") -Organization $orgRef
+             -SmtpServer "22.22.22.22" -SmtpRecipients @("xyz@test.com") -Organization $org

--- a/policies/ucs_server_policies/misc/ssh_policy/powershell/ssh_policy.ps1
+++ b/policies/ucs_server_policies/misc/ssh_policy/powershell/ssh_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # create a ssh policy
-$ssh_policy = New-IntersightSshPolicy -Name "ssh_policy_1" -Description "ssh policy" -Port 12000 -Timeout 1800 -Organization $orgRef
+$ssh_policy = New-IntersightSshPolicy -Name "ssh_policy_1" -Description "ssh policy" -Port 12000 -Timeout 1800 -Organization $org

--- a/policies/ucs_server_policies/network/adapter_configuation_policy/powershell/adapter_configuation_policy.ps1
+++ b/policies/ucs_server_policies/network/adapter_configuation_policy/powershell/adapter_configuation_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $ethSetting = Initialize-IntersightAdapterEthSettings -LldpEnabled $true
 
@@ -23,4 +23,4 @@ $adapterConfig = Initialize-IntersightAdapterAdapterConfig -DceInterfaceSettings
                     -FcSettings $fcsetting -PortChannelSettings $portChannelSetting -SlotId MLOM
 
 # create a adapter config policy
-$result = New-IntersightAdapterConfigPolicy -Name "adapter_config_policy" -Settings @($adapterConfig) -Organization $orgRef
+$result = New-IntersightAdapterConfigPolicy -Name "adapter_config_policy" -Settings @($adapterConfig) -Organization $org

--- a/policies/ucs_server_policies/network/ethernet_adapter_policy/powershell/ethernet_adapter_policy.ps1
+++ b/policies/ucs_server_policies/network/ethernet_adapter_policy/powershell/ethernet_adapter_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $ArfSettings = Initialize-IntersightVnicArfsSettings -Enabled $true
 
@@ -38,4 +38,4 @@ $result = New-IntersightVnicEthAdapterPolicy -Name "vnic_eth_adp_policy_1" -Adva
             -CompletionQueueSettings $CompletionQueSetting -InterruptSettings $interruptSetting -NvgreSettings $NvgreSetting `
             -PtpSettings $ptpSetting -RoceSettings $roceSetting -RssHashSettings $rsshSettings -RssSettings $true `
             -RxQueueSettings $rxQueueSetting -TcpOffloadSettings $tcpOffloadSetting -TxQueueSettings $txQueueSetting `
-            -VxlanSettings $vxlanSetting -Organization $orgRef
+            -VxlanSettings $vxlanSetting -Organization $org

--- a/policies/ucs_server_policies/network/ethernet_network_control_policy/powershell/ethernet_network_control_policy.ps1
+++ b/policies/ucs_server_policies/network/ethernet_network_control_policy/powershell/ethernet_network_control_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # initialize vlan settings
 $vlanSetting = Initialize-IntersightVnicVlanSettings -AllowedVlans "21-30" -DefaultVlan 21 -Mode ACCESS
@@ -19,4 +19,4 @@ $lldpSetting = Initialize-IntersightFabricLldpSettings -ReceiveEnabled $true -Tr
 # create a fabric.EthNetworkControlPolicy with above created network setting
 $Result = New-IntersightFabricEthNetworkControlPolicy -Name "eth_network_control_policy_1" -ForgeMac Allow `
          -MacRegistrationMode NativeVlanOnly -CdpEnabled $true -UplinkFailAction LinkDown `
-         -LldpSettings $lldpSetting -Organization $orgRef
+         -LldpSettings $lldpSetting -Organization $org

--- a/policies/ucs_server_policies/network/ethernet_network_group_policy/powershell/ethernet_network_group_policy.ps1
+++ b/policies/ucs_server_policies/network/ethernet_network_group_policy/powershell/ethernet_network_group_policy.ps1
@@ -8,11 +8,11 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # initialize vlan settings
 $valnSetting = Initialize-IntersightFabricVlanSettings -AllowedVlans "11,12,13" -NativeVlan 1
 
 # create a ethernet network group policy
-$result = New-IntersightFabricEthNetworkGroupPolicy -Name "fabricEthNetorkPolicy" -VlanSettings $valnSetting -Organization $orgRef
+$result = New-IntersightFabricEthNetworkGroupPolicy -Name "fabricEthNetorkPolicy" -VlanSettings $valnSetting -Organization $org

--- a/policies/ucs_server_policies/network/ethernet_network_policy/powershell/ethernet_network_policy.ps1
+++ b/policies/ucs_server_policies/network/ethernet_network_policy/powershell/ethernet_network_policy.ps1
@@ -8,10 +8,10 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $vlanSetting = Initialize-IntersightVnicVlanSettings -DefaultVlan 1 -AllowedVlans "11,12,13" -Mode TRUNK
 
 $result = New-IntersightVnicEthNetworkPolicy -Name "network_poicy_1" -VlanSettings $vlanSetting -TargetPlatform Standalone `
-            -Organization $orgRef
+            -Organization $org

--- a/policies/ucs_server_policies/network/ethernet_qos_policy/powershell/ethernet_qos_policy.ps1
+++ b/policies/ucs_server_policies/network/ethernet_qos_policy/powershell/ethernet_qos_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $result = New-IntersightVnicEthQosPolicy -Name "vnic_eth_qos_policy_1" -Priority BestEffort -Burst 1024 -Mtu 1500 `
-            -TrustHostCos $true -Organization $orgRef
+            -TrustHostCos $true -Organization $org

--- a/policies/ucs_server_policies/network/lan_connectivity_policy/powershell/lan_connectivity_policy.ps1
+++ b/policies/ucs_server_policies/network/lan_connectivity_policy/powershell/lan_connectivity_policy.ps1
@@ -8,13 +8,13 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # get the VnicEthIf ref object.
-$ethIfRef1 = Get-IntersightVnicEthIf -Name "eth0" | Get-IntersightMoMoRef
+$ethIfRef1 = Get-IntersightVnicEthIf -Name "eth0" 
 
-$ethIfRef2 = Get-IntersightVnicEthIf -Name "eth1" | Get-IntersightMoMoRef
+$ethIfRef2 = Get-IntersightVnicEthIf -Name "eth1" 
 
 $result = New-IntersightVnicLanConnectivityPolicy -Name "lan_connectivity_policy_1" -IqnAllocationType None -PlacementMode Custom -TargetPlatform Standalone `
-        -Organization $orgRef -AzureQosEnabled $false -EthIfs @($ethIfRef1,$ethIfRef2)
+        -Organization $org -AzureQosEnabled $false -EthIfs @($ethIfRef1,$ethIfRef2)

--- a/policies/ucs_server_policies/network/netwrok_connectivity_policy/powershell/netwrok_connectivity_policy.ps1
+++ b/policies/ucs_server_policies/network/netwrok_connectivity_policy/powershell/netwrok_connectivity_policy.ps1
@@ -8,9 +8,9 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $result = New-IntersightNetworkconfigPolicy -Name "netwrokConfigPolicy" -Description "test network config policy" -EnableDynamicDns $true `
             -DynamicDnsDomain "xyz.com" -EnableIpv6 $false -AlternateIpv4dnsServer "22.22.22.22" -PreferredIpv4dnsServer "171.70.98.1"`
-            -Organization $orgRef 
+            -Organization $org 

--- a/policies/ucs_server_policies/network/san_connectivity_policy/powershell/san_connectivity_policy.ps1
+++ b/policies/ucs_server_policies/network/san_connectivity_policy/powershell/san_connectivity_policy.ps1
@@ -8,11 +8,11 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # get the VnicEthIf ref object if it exist otherwise create a new using New-IntersightVnicEthIf.
-$fcIfRef2 = Get-IntersightVnicFcIf -Name "fc1" | Get-IntersightMoMoRef
+$fcIfRef2 = Get-IntersightVnicFcIf -Name "fc1" 
 
 $result = New-IntersightVnicSanConnectivityPolicy -Name "san_connectivity_policy_1" -PlacementMode Custom -TargetPlatform Standalone `
-        -Organization $orgRef -WwnnAddressType POOL 
+        -Organization $org -WwnnAddressType POOL 

--- a/policies/ucs_server_policies/storage/device_connector_policy/powershell/device_connector_policy.ps1
+++ b/policies/ucs_server_policies/storage/device_connector_policy/powershell/device_connector_policy.ps1
@@ -8,7 +8,7 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
-$result = New-IntersightDeviceconnectorPolicy -Name "device_connector_policy_1" -LockoutEnabled $true -Organization $orgRef
+$result = New-IntersightDeviceconnectorPolicy -Name "device_connector_policy_1" -LockoutEnabled $true -Organization $org

--- a/policies/ucs_server_policies/storage/fiber_channel_adapter_policy/powershell/fiber_channel_adapter_policy.ps1
+++ b/policies/ucs_server_policies/storage/fiber_channel_adapter_policy/powershell/fiber_channel_adapter_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $errorRecoverySetting = Initialize-IntersightVnicFcErrorRecoverySettings -Enabled $true -IoRetryCount 8 `
                         -IoRetryTimeout 5 -LinkDownTimeout 3000 -PortDownTimeout 5000
@@ -26,7 +26,7 @@ $scsiQueueSettings = Initialize-IntersightVnicScsiQueueSettings -Count 1 -RingSi
 
 $txQueueSettings = Initialize-IntersightVnicFcQueueSettings -RingSize 64
 
-$result = New-IntersightVnicFcAdapterPolicy -Name "fiber-channel-adapter-policy-1" -Organization $orgRef `
+$result = New-IntersightVnicFcAdapterPolicy -Name "fiber-channel-adapter-policy-1" -Organization $org `
             -ErrorDetectionTimeout 2000 -ErrorRecoverySettings $errorRecoverySetting -FlogiSettings $flogiSetting `
             -InterruptSettings $interruptSetting -IoThrottleCount 512 -LunCount 1024 -LunQueueDepth 20 `
             -PlogiSettings $plogiSettings -ResourceAllocationTimeout 10000 -RxQueueSettings $rxQueueSettings `

--- a/policies/ucs_server_policies/storage/fiber_channel_network_policy/powershell/fiber_channel_network_policy.ps1
+++ b/policies/ucs_server_policies/storage/fiber_channel_network_policy/powershell/fiber_channel_network_policy.ps1
@@ -8,9 +8,9 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $vsanSetting = Initialize-IntersightVnicVsanSettings -DefaultVlanId 22 -Id 22
 
-$result = New-IntersightVnicFcNetworkPolicy -Name "fc_network_policy_1" -Organization $orgRef -VsanSettings $vsanSetting
+$result = New-IntersightVnicFcNetworkPolicy -Name "fc_network_policy_1" -Organization $org -VsanSettings $vsanSetting

--- a/policies/ucs_server_policies/storage/fiber_channel_qos_policy/powershell/fiber_channel_qos_policy.ps1
+++ b/policies/ucs_server_policies/storage/fiber_channel_qos_policy/powershell/fiber_channel_qos_policy.ps1
@@ -8,7 +8,7 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
-$Result = New-IntersightVnicFcQosPolicy -Name "fc_qos_policy_1" -Organization $orgRef -Burst 1024 -Cos 3 -MaxDataFieldSize 2112 -RateLimit 2048
+$Result = New-IntersightVnicFcQosPolicy -Name "fc_qos_policy_1" -Organization $org -Burst 1024 -Cos 3 -MaxDataFieldSize 2112 -RateLimit 2048

--- a/policies/ucs_server_policies/storage/iscsi_adapter_policy/powershell/iscsi_adapter_policy.ps1
+++ b/policies/ucs_server_policies/storage/iscsi_adapter_policy/powershell/iscsi_adapter_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
-$result = New-IntersightVnicIscsiAdapterPolicy -Name "iscsi_adapter_policy_1" -Organization $orgRef -ConnectionTimeOut 255 `
+$result = New-IntersightVnicIscsiAdapterPolicy -Name "iscsi_adapter_policy_1" -Organization $org -ConnectionTimeOut 255 `
             -DhcpTimeout 300 -LunBusyRetryCount 60 

--- a/policies/ucs_server_policies/storage/iscsi_boot_policy/powershell/iscsi_boot_policy.ps1
+++ b/policies/ucs_server_policies/storage/iscsi_boot_policy/powershell/iscsi_boot_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $chap = Initialize-IntersightVnicIscsiAuthProfile -Password "test@11234567" -UserId test
 
@@ -19,15 +19,15 @@ $mutualChap = Initialize-IntersightVnicIscsiAuthProfile -Password "test@1234567"
 
 # create a vnic iscsi adapter policy
 $iscsiAdapterPolicyRef = New-IntersightVnicIscsiAdapterPolicy -Name "iscsi_adapter_policy_1" -DhcpTimeout 300 -LunBusyRetryCount 25 `
-                         -ConnectionTimeOut 150 -Organization $orgRef | Get-IntersightMoMoRef
+                         -ConnectionTimeOut 150 -Organization $org 
 
 #initialize vnic lun
 $lunSetting = Initialize-IntersightVnicLun -Bootable $true -LunId 0
 
 # create primary target policy and get the ref of it
-$primaryTargetPOlicyRef = New-IntersightVnicIscsiStaticTargetPolicy -Name "primary_target_1" -IpAddress "10.193.250.251" `
-                          -Port 3232 -TargetName "iqn.2020-12.com.abc:001"  -Organization $orgRef| Get-IntersightMoMoRef
+$primaryTargetPOlicy = New-IntersightVnicIscsiStaticTargetPolicy -Name "primary_target_1" -IpAddress "10.193.250.251" `
+                          -Port 3232 -TargetName "iqn.2020-12.com.abc:001"  -Organization $org
 
-$result =  New-IntersightVnicIscsiBootPolicy -Name "iscsi_boot_policy_1" -Organization $orgRef -InitiatorIpSource Static -TargetSourceType Static `
+$result =  New-IntersightVnicIscsiBootPolicy -Name "iscsi_boot_policy_1" -Organization $org -InitiatorIpSource Static -TargetSourceType Static `
             -Chap $chap -InitiatorStaticIpV4Address "172.16.2.19" -InitiatorStaticIpV4Config $initiatorStaticIpV4Config `
-            -IscsiAdapterPolicy $iscsiAdapterPolicyRef -PrimaryTargetPolicy $primaryTargetPolicyRef -MutualChap $mutualChap
+            -IscsiAdapterPolicy $iscsiAdapterPolicyRef -PrimaryTargetPolicy $primaryTargetPolicy -MutualChap $mutualChap

--- a/policies/ucs_server_policies/storage/iscsi_static_target_policy/powershell/iscsi_static_target_policy.ps1
+++ b/policies/ucs_server_policies/storage/iscsi_static_target_policy/powershell/iscsi_static_target_policy.ps1
@@ -8,10 +8,10 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $lun = Initialize-IntersightVnicLun -Bootable $true -LunId 100
 
-$result = New-IntersightVnicIscsiStaticTargetPolicy -Name "iscsi_target_policy_1" -Organization $orgRef -IpAddress "172.16.18.11" `
+$result = New-IntersightVnicIscsiStaticTargetPolicy -Name "iscsi_target_policy_1" -Organization $org -IpAddress "172.16.18.11" `
             -Lun $lun -Port 3260 -TargetName "iqn.1992-08.com.netapp:sn.bbe560cbd84911ebad8ad039ea153259:vs.5"

--- a/policies/ucs_server_policies/storage/sd_card_policy/powershell/sd_card_policy.ps1
+++ b/policies/ucs_server_policies/storage/sd_card_policy/powershell/sd_card_policy.ps1
@@ -8,11 +8,11 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $virtualDrives = Initialize-IntersightSdcardVirtualDrive -Enable $true -ClassId SdcardDrivers -ObjectType SdcardDrivers
 
 $partitions = Initialize-IntersightSdcardPartition -Type Utility -VirtualDrives $virtualDrives
 
-$result = New-IntersightSdcardPolicy -Name "sd-card-policy-1" -Organization $orgRef -Partitions $partitions
+$result = New-IntersightSdcardPolicy -Name "sd-card-policy-1" -Organization $org -Partitions $partitions

--- a/policies/ucs_server_policies/storage/storage_policy/powershell/storage_policy.ps1
+++ b/policies/ucs_server_policies/storage/storage_policy/powershell/storage_policy.ps1
@@ -8,8 +8,8 @@ $config = @{
 # Set intersight configuration    
 Set-IntersightConfiguration @config
 
-# get the Organization Ref.
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+# get the Organization.
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $m2VirtualDrive = Initialize-IntersightStorageM2VirtualDriveConfig -Enable $true -ControllerSlot MSTORRAID1
 
@@ -17,5 +17,5 @@ $virtualDrivePolicy = Initialize-IntersightStorageVirtualDrivePolicy -DriveCache
 
 $raid0Drive = Initialize-IntersightStorageR0Drive -Enable $true -VirtualDrivePolicy $virtualDrivePolicy
 
-$result = New-IntersightStorageStoragePolicy -Name "storage_policy_1" -Organization $orgRef -DefaultDriveMode RAID0 `
+$result = New-IntersightStorageStoragePolicy -Name "storage_policy_1" -Organization $org -DefaultDriveMode RAID0 `
              -M2VirtualDrive $m2VirtualDrive -Raid0Drive $raid0Drive

--- a/pool/IP/powershell/IPPool.ps1
+++ b/pool/IP/powershell/IPPool.ps1
@@ -9,7 +9,7 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # get organization ref
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # initialize IPv4 config
 $ipv4Config = Initialize-IntersightIppoolIpV4Config -Gateway "10.108.190.1" -Netmask "255.255.255.0" -PrimaryDns "10.108.190.100"
@@ -18,4 +18,4 @@ $ipv4Config = Initialize-IntersightIppoolIpV4Config -Gateway "10.108.190.1" -Net
 $IPv4Block = Initialize-IntersightIppoolIpV4Block -From "10.108.190.11" -To "10.108.190.20"
 
 # create IPpool
-$result = New-IntersightIppoolPool -Name IpPool_1 -IpV4Blocks @($IPv4Block) -IpV4Config $ipv4Config -Organization $orgRef
+$result = New-IntersightIppoolPool -Name IpPool_1 -IpV4Blocks @($IPv4Block) -IpV4Config $ipv4Config -Organization $org

--- a/pool/IQN/powershell/IQNPool.ps1
+++ b/pool/IQN/powershell/IQNPool.ps1
@@ -9,10 +9,10 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # get organization MoRef
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 $iqnSuffixBlock = Initialize-IntersightIqnpoolIqnSuffixBlock -Suffix "iscsi01" -From 0 -To 9
 
 # create IqnPool
 $result = New-IntersightIqnpoolPool -Name IQNPool_1 -Prefix "iqn.2023-06.abc.com" -IqnSuffixBlocks $iqnSuffixBlock `
-          -Organization $orgRef
+          -Organization $org

--- a/pool/IQN/readme.md
+++ b/pool/IQN/readme.md
@@ -1,4 +1,4 @@
 ## IQN pool
-An IQN pool is a collection of iSCSI Qualified Names ``(IQNs)`` for use as initiator identifiers by iSCSI vNICs. IQN pool members are of the form prefix: suffix: number, where you can specify the prefix, suffix, and a block (range) of numbers.
+An IQN pool is a collection of iSCSI Qualified Names (IQNs) for use as initiator identifiers by iSCSI vNICs. IQN pool members are of the form prefix: suffix: number, where you can specify the prefix, suffix, and a block (range) of numbers.
 
 An IQN pool can contain more than one IQN block, with different number ranges and different suffixes, but sharing the same prefix. 

--- a/pool/MAC/powershell/MACPool.ps1
+++ b/pool/MAC/powershell/MACPool.ps1
@@ -9,10 +9,10 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # ger organization MoRef
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 #initialize MAC pool bock
 $macPoolBlock = Initialize-IntersightMacpoolBlock -From "00:25:B5:00:00:01" -Size 10
 
 #create MAC pool
-$result = New-IntersightMacpoolPool -Name "MAC_pool_1" -AssignmentOrder Sequential -MacBlocks $macPoolBlock -Organization $orgRef
+$result = New-IntersightMacpoolPool -Name "MAC_pool_1" -AssignmentOrder Sequential -MacBlocks $macPoolBlock -Organization $org

--- a/pool/Resource/powershell/ResourcePool.ps1
+++ b/pool/Resource/powershell/ResourcePool.ps1
@@ -9,7 +9,7 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # get organization ref
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # initialize resource pool parameter
 $ResourcePoolParameters1 = Initialize-IntersightResourcepoolServerPoolParameters -ManagementMode "IntersightStandalone"
@@ -18,4 +18,4 @@ $ResourcePoolParameters1 = Initialize-IntersightResourcepoolServerPoolParameters
 $resourceSelector = Initialize-IntersightResourceSelector -Selector "/api/v1/compute/RackUnits?`$filter=(Serial eq 'EMEDDEC6E0')"
 
  $result = New-IntersightResourcepoolPool -Name "Resource_pool_1" -AssignmentOrder Sequential -PoolType Static `
-           -Organization $orgRef  -Selectors $resourceSelector -ResourcePoolParameters $ResourcePoolParameters1
+           -Organization $org  -Selectors $resourceSelector -ResourcePoolParameters $ResourcePoolParameters1

--- a/pool/UUID/powershell/UUIDPool.ps1
+++ b/pool/UUID/powershell/UUIDPool.ps1
@@ -9,11 +9,11 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # get organization MoRef
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # initialize UUID block 
 $UuidSuffixBlocks11 = Initialize-IntersightUuidpoolUuidBlock -From "0000-001234500A00" -Size 100
 
 # create UUID pool
 $result = New-IntersightUuidpoolPool -Name "uuuid_pool_1" -Prefix "00000000-0000-00A0"  -UuidSuffixBlocks @($UuidSuffixBlocks11) `
-       -AssignmentOrder "Default" -Organization $orgRef
+       -AssignmentOrder "Default" -Organization $org

--- a/pool/WWNN/powershell/WWNNPool.ps1
+++ b/pool/WWNN/powershell/WWNNPool.ps1
@@ -9,11 +9,11 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # get organization MoRef
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # initialize FC pool block
 $fcBlocks = Initialize-IntersightFcpoolBlock -From "20:00:00:25:B5:00:00:01" -Size 100 
 
 # create WWNN pool
 $result = New-IntersightFcpoolPool -Name "wwnn_pool_1" -AssignmentOrder "Default" -IdBlocks @($fcBlocks) -PoolPurpose "WWNN" `
-          -Organization $orgRef
+          -Organization $org

--- a/pool/WWPN/powershell/WWPNPool.ps1
+++ b/pool/WWPN/powershell/WWPNPool.ps1
@@ -9,11 +9,11 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # get organization MoRef
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # initialize FC pool block
 $fcPoolBlocks = Initialize-IntersightFcpoolBlock -From "20:00:00:25:B5:00:10:00" -Size 100
 
 # create WWPN pool
 $result = New-IntersightFcpoolPool -Name "wwpn_pool_1" -PoolPurpose "WWPN" -IdBlocks @($fcPoolBlocks)`
-          -AssignmentOrder "Default" -Organization $orgRef
+          -AssignmentOrder "Default" -Organization $org

--- a/profile/ucs_chassis_profile/powershell/ucs_chassis_profile.ps1
+++ b/profile/ucs_chassis_profile/powershell/ucs_chassis_profile.ps1
@@ -9,14 +9,14 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # get the Organization MoRef
-$orgRef = Get-IntersightOrganizationOrganization -Name "default" | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name "default" 
 
-# get MoRef of chassis policies 
-$imcAccessRef = Get-IntersightAccessPolicy -Name "access_policy_1" | Get-IntersightMoMoRef
-$powerPolicyRef = Get-IntersightPowerPolicy -Name "power_policy_1" | Get-IntersightMoMoRef
-$snmpPolicyRef = Get-IntersightSnmpPolicy -Name "snmp_policy_1" | Get-IntersightMoMoRef
-$thermalPolicyRef = Get-IntersightThermalPolicy -Name "thermal_policy_1" | Get-IntersightMoMoRef
+# get chassis policies 
+$imcAccess = Get-IntersightAccessPolicy -Name "access_policy_1" 
+$powerPolicy = Get-IntersightPowerPolicy -Name "power_policy_1" 
+$snmpPolicy = Get-IntersightSnmpPolicy -Name "snmp_policy_1" 
+$thermalPolicy = Get-IntersightThermalPolicy -Name "thermal_policy_1" 
 
 # create a chassis profile
-$chassisProfile = New-IntersightChassisProfile -Name "sample_chassis_profile_1" -Organization $orgRef `
-                  -PolicyBucket @($imcAccessRef,$powerPolicyRef,$snmpPolicyRef,$thermalPolicyRef)
+$chassisProfile = New-IntersightChassisProfile -Name "sample_chassis_profile_1" -Organization $org `
+                  -PolicyBucket @($imcAccess,$powerPolicy,$snmpPolicy,$thermalPolicy)

--- a/profile/ucs_domain_profile/powershell/ucs_domain_profile.ps1
+++ b/profile/ucs_domain_profile/powershell/ucs_domain_profile.ps1
@@ -9,29 +9,26 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # Get organization MoRef
-$orgRef = Get-IntersightOrganizationOrganization -Name "default" | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name "default" 
 
-# get the policies MoRef for domain profile.
-$ethNetworkRef = Get-IntersightFabricEthNetworkPolicy -Name "eth_network_policy_1" | Get-IntersightMoMoRef
-$fcNetworkRef = Get-IntersightFabricFcNetworkPolicy -Name "fc_network_policy_1" | Get-IntersightMoMoRef
-$portRef = Get-IntersightFabricPortPolicy -Name "port_policy_1" | Get-IntersightMoMoRef
-$systemQoSRef = Get-IntersightFabricSystemQosPolicy -Name "system_qos_policy_1" | Get-IntersightMoMoRef
-$switchControlRef = Get-IntersightFabricSwitchControlPolicy -Name "switch_control_policy_1" | Get-IntersightMoMoRef
-$ntpRef = Get-IntersightNtpPolicy -Name  "ntp_policy_1" | Get-IntersightMoMoRef
-$syslogRef = Get-IntersightSyslogPolicy -Name "syslog_policy_1" | Get-IntersightMoMoRef
-$networkConfigRef = Get-IntersightNetworkconfigPolicy -Name "network_config_policy_1" | Get-IntersightMoMoRef
-$snmpRef =  Get-IntersightSnmpPolicy -Name "snmp_policy_1" | Get-IntersightMoMoRef
+# get the domain profile policies.
+$ethNetwork = Get-IntersightFabricEthNetworkPolicy -Name "eth_network_policy_1" 
+$fcNetwork = Get-IntersightFabricFcNetworkPolicy -Name "fc_network_policy_1" 
+$port = Get-IntersightFabricPortPolicy -Name "port_policy_1" 
+$systemQoS = Get-IntersightFabricSystemQosPolicy -Name "system_qos_policy_1" 
+$switchControl = Get-IntersightFabricSwitchControlPolicy -Name "switch_control_policy_1" 
+$ntp = Get-IntersightNtpPolicy -Name  "ntp_policy_1" 
+$syslog = Get-IntersightSyslogPolicy -Name "syslog_policy_1" 
+$networkConfig = Get-IntersightNetworkconfigPolicy -Name "network_config_policy_1" 
+$snmp =  Get-IntersightSnmpPolicy -Name "snmp_policy_1" 
 
 # create a domain profile for Fabric switch A
 $fabric_A_Prfile = New-IntersightFabricSwitchProfile -Name "Fabric_A_profile" `
-                   -PolicyBucket @($ethNetworkRef,$fcNetworkRef,$PortRef,$systemQoSRef,$switchControlRef,$ntpRef,$syslogRef,$snmpRef,$networkConfigRef)
+                   -PolicyBucket @($ethNetwork,$fcNetwork,$Port,$systemQoS,$switchControl,$ntp,$syslog,$snmp,$networkConfig)
 
 # create a domain profile for fabric switch B
 $fabric_B_Profile = New-IntersightFabricSwitchProfile -Name "Fabric_B_profile" `
-                    -PolicyBucket @($ethNetworkRef,$fcNetworkRef,$PortRef,$systemQoSRef,$switchControlRef,$ntpRef,$syslogRef,$snmpRef,$networkConfigRef)
+                    -PolicyBucket @($ethNetwork,$fcNetwork,$Port,$systemQoS,$switchControl,$ntpRef,$syslog,$snmp,$networkConfig)
 
-# create cluster switch policy
-$fabric_A_ProfileRef = $fabric_A_Prfile | Get-IntersightMoMoRef
-$fabric_B_ProfileRef = $fabric_B_Profile | Get-IntersightMoMoRef
-$clusterSiwtchPolicy = New-IntersightFabricSwitchClusterProfile -Name "cluster_switch_profile_1" -Organization $orgRef `
-                       -SwitchProfiles @($fabric_A_ProfileRef,$fabric_B_ProfileRef)
+$clusterSiwtchPolicy = New-IntersightFabricSwitchClusterProfile -Name "cluster_switch_profile_1" -Organization $org `
+                       -SwitchProfiles @($fabric_A_Prfile,$fabric_B_Profile)

--- a/profile/ucs_server_profile/powershell/ucs_server_profile.ps1
+++ b/profile/ucs_server_profile/powershell/ucs_server_profile.ps1
@@ -9,38 +9,38 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # Get organization MoRef
-$organization1 = Get-IntersightOrganizationOrganization -Name 'default' | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name default
 
 # create ntp, smtp and smnp policies for server profile
 
 # Creating NTP policy and get MoRef
-$ntpRef = New-IntersightNtpPolicy -Organization $organization1 -Name 'ntp1' -Description 'test policy' -Enabled 1 `
-        -NtpServers @('ntp.esl.cisco.com', 'time-a-g.nist.gov', 'time-b-g.nist.gov') | Get-IntersightMoMoRef
+$ntp = New-IntersightNtpPolicy -Organization $org -Name 'ntp1' -Description 'test policy' -Enabled 1 `
+        -NtpServers @('ntp.esl.cisco.com', 'time-a-g.nist.gov', 'time-b-g.nist.gov') 
 
 # Creating SMTP policy and get MoRef
-$smtpRef = New-IntersightSmtpPolicy -Organization $organization1 -Enabled 0 -Name 'smtp1' -Description 'testing smtp policy' `
+$smtp = New-IntersightSmtpPolicy -Organization $org -Enabled 0 -Name 'smtp1' -Description 'testing smtp policy' `
          -SmtpPort 32 -MinSeverity 'critical' -SmtpServer '10.10.10.1' -SenderEmail 'IMCSQAAutomation@cisco.com' `
-         -SmtpRecipients @('aw@cisco.com', 'cy@cisco.com', 'dz@cisco.com') | Get-IntersightMoMoRef
+         -SmtpRecipients @('aw@cisco.com', 'cy@cisco.com', 'dz@cisco.com') 
 
 # Creating SNMP policy and get MoRef
 $snmp_users1 = Initialize-IntersightSnmpUser -Name 'demouser' -PrivacyType 'AES' -SecurityLevel 'AuthPriv' -AuthType 'SHA' -AuthPassword 'dummyPassword' -PrivacyPassword 'dummyPrivatePassword'
 $snmp_traps1 = Initialize-IntersightSnmpTrap -Destination '10.10.10.1' -Enabled 0 -Type 'Trap' -User 'demouser' -Port 660 -ObjectType 'SnmpTrap' -Version 'V3'
-$snmpRef = New-IntersightSnmpPolicy -Name 'snmp1' -Description 'testing smtp policy' -Enabled 1 -SnmpPort 1983 `
-         -SnmpUsers $snmp_users1 -SnmpTraps $snmp_traps1 -Organization $organization1 -AccessCommunityString 'dummy123' `
+$snmp = New-IntersightSnmpPolicy -Name 'snmp1' -Description 'testing smtp policy' -Enabled 1 -SnmpPort 1983 `
+         -SnmpUsers $snmp_users1 -SnmpTraps $snmp_traps1 -Organization $org -AccessCommunityString 'dummy123' `
          -CommunityAccess 'Disabled' -TrapCommunity 'TrapCommunity' -SysContact 'xyz' -SysLocation 'SJC' -EngineId 'abc' `
-         | Get-IntersightMoMoRef
+         
 
 
 # Create a server profile Tag
 $tags1 = Initialize-IntersightMoTag -Key 'server' -Value 'demo'
 
 # create a server profile
-$serverProfile = New-IntersightServerProfile -Name "ss_server_profile1" -Description "A sample server profile"  -Organization $Organization1 `
-                            -Tags $tags1 -TargetPlatform "Standalone" -PolicyBucket @($ntpRef, $smtpRef, $snmpRef) `
+$serverProfile = New-IntersightServerProfile -Name "server_profile1" -Description "A sample server profile"  -Organization $org `
+                            -Tags $tags1 -TargetPlatform "Standalone" -PolicyBucket @($ntp, $smtp, $snmp) `
                             
 # assigned server profile to a server. Get the RackUnit or BladeUnit MoRef
-$serverRef = Get-IntersightComputeRackunit -Moid '<Replace with Moid>' | Get-IntersightMoMoRef
-$serverProfile | Set-IntersightServerProfile -AssignedServer $serverRef
+$server = Get-IntersightComputeRackunit -Moid '<Replace with Moid>' 
+$serverProfile | Set-IntersightServerProfile -AssignedServer $server
 
 # deploy server profile to assigned server.
 $serverProfile | Set-IntersightServerProfile -Action 'Deploy'

--- a/template/ucs_server_profile_template/powershell/ucs_server_profile_template.ps1
+++ b/template/ucs_server_profile_template/powershell/ucs_server_profile_template.ps1
@@ -9,20 +9,20 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # Get a organization ref. 
-$orgRef = Get-IntersightOrganizationOrganization -Name "default" | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name "default" 
 
 # create ntp policy and get MoRef
-$ntpPolicyRef = New-IntersightNtpPolicy -Name "ntp_policy_11" -NtpServers @("22.22.22.33","44.44.44.44") -Enabled $true `
-                -Organization $orgRef | Get-IntersightMoMoRef
+$ntpPolicy = New-IntersightNtpPolicy -Name "ntp_policy_11" -NtpServers @("22.22.22.33","44.44.44.44") -Enabled $true `
+                -Organization $org 
 
 # create bios policy and get MoRef
-$biosPolicyRef = New-IntersightBiosPolicy -Name "bios_policy_11" -BootOptionRetry Enabled -IntelTurboBoostTech Enabled `
-                -Organization $orgRef | Get-IntersightMoMoRef
+$biosPolicy = New-IntersightBiosPolicy -Name "bios_policy_11" -BootOptionRetry Enabled -IntelTurboBoostTech Enabled `
+                -Organization $org 
 
 # create kvm policy and get kvm policy
-$kvmPolicyRef = New-IntersightKvmPolicy -Name "kvm_policy_11" -EnableLocalServerVideo $true -EnableVideoEncryption $true `
-                -Enabled $true -Organization $orgRef | Get-IntersightMoMoRef
+$kvmPolicy = New-IntersightKvmPolicy -Name "kvm_policy_11" -EnableLocalServerVideo $true -EnableVideoEncryption $true `
+                -Enabled $true -Organization $org 
 
 # create a ServerProfile template.
 $result = New-IntersightServerProfileTemplate -Name "Server_Profile_template_1" `
-          -PolicyBucket @($ntpPolicyRef,$biosPolicyRef,$kvmPolicyRef) -Organization $orgRef
+          -PolicyBucket @($ntpPolicy,$biosPolicy,$kvmPolicy) -Organization $org

--- a/ucs_server/compute/firmware_policy/powershell/firmware_policy.ps1
+++ b/ucs_server/compute/firmware_policy/powershell/firmware_policy.ps1
@@ -8,11 +8,11 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # get organization MoRef
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # initialize Model bundle version
 $modelBundleVersion = Initialize-IntersightFirmwareModelBundleVersion -ModelFamily UCSCC220M7 -BundleVersion "4.3(3.240043)"
 
 # create firmware policy
 $result = New-IntersightFirmwarePolicy -Name "firmware_policy_1" -TargetPlatform Standalone -ModelBundleCombo $modelBundleVersion `
-          -Organization $orgRef
+          -Organization $org

--- a/ucs_server/compute/thermal_policy/powershell/thermal_policy.ps1
+++ b/ucs_server/compute/thermal_policy/powershell/thermal_policy.ps1
@@ -9,7 +9,7 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # get organization MoRef
-$orgRef = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # create thermal policy
-$result = New-IntersightThermalPolicy -Name "thermal_policy_1" -FanControlMode Balanced -Organization $orgRef
+$result = New-IntersightThermalPolicy -Name "thermal_policy_1" -FanControlMode Balanced -Organization $org

--- a/ucs_server/management/ipmi_over_lan_policy/powershell/ipmi_over_lan_policy.ps1
+++ b/ucs_server/management/ipmi_over_lan_policy/powershell/ipmi_over_lan_policy.ps1
@@ -9,10 +9,7 @@ $config = @{
 Set-IntersightConfiguration @config
 
 # get the existing default org. One can create new Organization using New-IntersightOrganizationOrganization cmdlets.
-$org = Get-IntersightOrganizationOrganization -Name default | Get-IntersightMoMoRef
-
-# get organizationRef
-$orgRef = $org | Get-IntersightMoMoRef
+$org = Get-IntersightOrganizationOrganization -Name default 
 
 # create a IPMI over LAN policy
-$result = New-IntersightIpmioverlanPolicy -Name "ipmi_over_lan_1" -Enabled $true -Privilege Admin -Organization $orgRef -EncryptionKey "FFFFAAAA99990006752896ABCDED"
+$result = New-IntersightIpmioverlanPolicy -Name "ipmi_over_lan_1" -Enabled $true -Privilege Admin -Organization $org -EncryptionKey "FFFFAAAA99990006752896ABCDED"


### PR DESCRIPTION
I have refactored the PowerShell samples to use the MO return from the Get/New cmdlet with the parameter of Relationship type. There is no need to convert it to MoMoref and then pass it to the parameter of Relationship.